### PR TITLE
Fix Angular build output path for browser subfolder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY *.sln ./
 COPY AiPortfolioAnalysis.Web/*.csproj ./AiPortfolioAnalysis.Web/
 RUN dotnet restore
 COPY AiPortfolioAnalysis.Web/ ./AiPortfolioAnalysis.Web/
-COPY --from=frontend-build /app/clientapp/dist/ClientApp/ ./AiPortfolioAnalysis.Web/wwwroot/
+COPY --from=frontend-build /app/clientapp/dist/ClientApp/browser/ ./AiPortfolioAnalysis.Web/wwwroot/
 RUN dotnet publish AiPortfolioAnalysis.Web/AiPortfolioAnalysis.Web.csproj -c Release -o out -p:BuildingInDocker=true
 
 # Runtime stage


### PR DESCRIPTION
## Summary
- Fix Dockerfile to copy Angular build output from correct path
- Angular's @angular/build:application builder outputs to browser subfolder
- Resolves SPA middleware error: index.html not found

## Root Cause
The Angular build system was updated to use `@angular/build:application` builder which outputs the production build to `dist/ClientApp/browser/` instead of `dist/ClientApp/`. The Dockerfile was copying from the wrong path, causing the SPA middleware to fail finding `index.html`.

## Changes
- Updated Dockerfile line 16 to copy from `/app/clientapp/dist/ClientApp/browser/` instead of `/app/clientapp/dist/ClientApp/`

## Test Plan
- [x] Build and deploy to verify index.html is found
- [x] Verify SPA routing works correctly
- [x] Confirm static assets are served properly

## Related Issues
- Fixes #20
- Follows up on #13 CI/CD pipeline implementation

🤖 Generated with [Claude Code](https://claude.ai/code)